### PR TITLE
This version # needs to match the tag/release number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "sparksuite/php-whois",
     "description": "Whois client.",
     "keywords": ["whois"],
-    "version": "1.0.2",
+    "version": "1.0.4",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Please cut another release (1.0.4) with this version of the composer.json file.